### PR TITLE
Fix bug file://127.0.0.1

### DIFF
--- a/src/parity/dappsUrl.js
+++ b/src/parity/dappsUrl.js
@@ -18,7 +18,7 @@ import { computed } from 'mobx';
 import createMobxStore from '../utils/createMobxStore';
 
 const dappsUrlFactory = (...params) => {
-  const BaseStore = createMobxStore({})('parity')('dappsUrl')(...params);
+  const BaseStore = createMobxStore()('parity')('dappsUrl')(...params);
 
   return class DappsUrlStore extends BaseStore {
     /**
@@ -26,9 +26,13 @@ const dappsUrlFactory = (...params) => {
      */
     @computed
     get fullUrl () {
-      return this.dappsUrl && this.dappsUrl.includes('//')
-        ? this.dappsUrl
-        : `${window.location.protocol}//${this.dappsUrl}`;
+      if (!this.dappsUrl) return null;
+
+      if (this.dappsUrl.includes('//')) return this.dappsUrl;
+
+      return window.location.protocol.includes('http')
+        ? `${window.location.protocol}//${this.dappsUrl}`
+        : `http://${this.dappsUrl}`; // Default to http
     }
   };
 };

--- a/src/parity/dappsUrl.spec.js
+++ b/src/parity/dappsUrl.spec.js
@@ -33,7 +33,7 @@ test('should handle fullUrl with partial dappsUrl', () => {
   const store = dappsUrlFactory().get(mockApi);
   store.setDappsUrl('127.0.0.1:8545');
 
-  expect(store.fullUrl).toEqual('about://127.0.0.1:8545'); // Protocol is about:// in tests
+  expect(store.fullUrl).toEqual('http://127.0.0.1:8545'); // Protocol is about:// in tests
 });
 
 test('should handle fullUrl with full dappsUrl', () => {

--- a/src/parity/dappsUrl.spec.js
+++ b/src/parity/dappsUrl.spec.js
@@ -29,11 +29,29 @@ const mockApi = {
 
 basicStoreTests('parity')('dappsUrl')(dappsUrlFactory)();
 
-test('should handle fullUrl with partial dappsUrl', () => {
+test('should return null if no dappsUrl', () => {
+  const store = dappsUrlFactory().get(mockApi);
+
+  expect(store.fullUrl).toEqual(null);
+});
+
+test('should handle fullUrl with partial dappsUrl in about: protocol', () => {
   const store = dappsUrlFactory().get(mockApi);
   store.setDappsUrl('127.0.0.1:8545');
 
   expect(store.fullUrl).toEqual('http://127.0.0.1:8545'); // Protocol is about:// in tests
+});
+
+test('should handle fullUrl with partial dappsUrl in https: protocol', () => {
+  const store = dappsUrlFactory().get(mockApi);
+  // Mock window.location.protocol
+  Object.defineProperty(window.location, 'protocol', {
+    writable: true,
+    value: 'https:'
+  });
+  store.setDappsUrl('127.0.0.1:8545');
+
+  expect(store.fullUrl).toEqual('https://127.0.0.1:8545'); // Protocol is about:// in tests
 });
 
 test('should handle fullUrl with full dappsUrl', () => {


### PR DESCRIPTION
Don't allow an url of type `file://127.0.0.1`, defaults to http if file: protocol